### PR TITLE
[minor] Adds toString method to ConstDateTime

### DIFF
--- a/lib/src/const_date_time.dart
+++ b/lib/src/const_date_time.dart
@@ -197,6 +197,11 @@ class ConstDateTime implements DateTime {
   }
 
   @override
+  String toString() {
+    return dateTime.toString();
+  }
+
+  @override
   dynamic noSuchMethod(Invocation invocation) {
     // Note: This solution is only valid on Flutter 3.3 / Dart 2.18
     //

--- a/test/const_date_time_test.dart
+++ b/test/const_date_time_test.dart
@@ -194,5 +194,11 @@ void main() {
       expect(constDateTime.timeZoneOffset.inHours == 0, isTrue);
       expect(constDateTime.timeZoneOffset.inMinutes == 0, isTrue);
     });
+
+    test('toString', () {
+      var constDateTime = const ConstDateTime(0, 1, 2, 3, 4, 5, 6, 7);
+      var dateTime = DateTime(0, 1, 2, 3, 4, 5, 6, 7);
+      expect(constDateTime.toString() == dateTime.toString(), isTrue);
+    });
   });
 }


### PR DESCRIPTION
Hi @westy92, 👋 

the toString() method of `ConstDateTime` just prints `Instance of 'ConstDateTime'` which isn't really helpful when debugging. This MR relies on `DateTime`'s implementation of `toString` similar to other overloaded functions.

Thank you for this library 🙌 