### PR TITLE
[minor] Overrides runtimeType

### DIFF
--- a/lib/src/const_date_time.dart
+++ b/lib/src/const_date_time.dart
@@ -217,6 +217,11 @@ class ConstDateTime implements DateTime {
     }
     return super.noSuchMethod(invocation);
   }
+
+  /// As `ConstDateTime` is a decorator type on top of `DateTime`
+  /// we treat it as the ~same~ type for Equatability checks.
+  @override
+  Type get runtimeType => DateTime;
 }
 
 /// @see [kIsWeb](https://api.flutter.dev/flutter/foundation/kIsWeb-constant.html)

--- a/lib/src/const_date_time.dart
+++ b/lib/src/const_date_time.dart
@@ -218,8 +218,11 @@ class ConstDateTime implements DateTime {
     return super.noSuchMethod(invocation);
   }
 
-  /// As `ConstDateTime` is a decorator type on top of `DateTime`
-  /// we treat it as the ~same~ type for Equatability checks.
+  /// `ConstDateTime` is a decorator type built upon `DateTime`, and we intend
+  /// to treat them as the **same** type at runtime. Certain libraries, such as
+  /// [Equatable](https://pub.dev/packages/equatable), depend on matching
+  /// `runtimeType` for their equality checks. We override the `runtimeType`
+  /// to ensure these checks succeed.
   @override
   Type get runtimeType => DateTime;
 }

--- a/test/const_date_time_test.dart
+++ b/test/const_date_time_test.dart
@@ -200,5 +200,12 @@ void main() {
       var dateTime = DateTime(0, 1, 2, 3, 4, 5, 6, 7);
       expect(constDateTime.toString() == dateTime.toString(), isTrue);
     });
+
+    test('runtimeType', () {
+      var constDateTime = const ConstDateTime(0, 1, 2, 3, 4, 5, 6, 7);
+      var dateTime = DateTime(0, 1, 2, 3, 4, 5, 6, 7);
+
+      expect(constDateTime.runtimeType == dateTime.runtimeType, isTrue);
+    });
   });
 }


### PR DESCRIPTION
Once again, hi! 👋 👻 

We ran into some issues in our snapshot tests relying on `Equatable` types. As we needed to inject a `const DateTime` in a immutable struct, I stumbled upon this library, allowing me to properly test our data objects. We rely on the `Equatable` package to synthesise equality checks for these objects. Unfortunately, Equatable relies on [runtimeType equality](https://github.com/felangel/equatable/blob/725b76c9ef072695f3ae4f036c4fa5e015528f13/lib/src/equatable_utils.dart#L26) of all properties in the checks and was therefore failing the test assertion.

It's quite easy to reproduce:
```dart
import 'package:equatable/equatable.dart';
import 'package:const_date_time/const_date_time.dart';

class SomeType extends Equatable {
  final DateTime date;

  SomeType({
    required this.date,
  });

  @override
  List<Object?> get props => [date];
}

void main() {
  print(SomeType(date: DateTime.fromMicrosecondsSinceEpoch(0)) == SomeType(date: ConstDateTime.fromMicrosecondsSinceEpoch(0)));
  
  print(DateTime.fromMicrosecondsSinceEpoch(0) == ConstDateTime.fromMicrosecondsSinceEpoch(0))
}
```

This example will print `false` even though the equality check implemented in `ConstDateTime` class prints `true`.

As it requires a bigger pull request on `Equatable` and some more in-depth thinking how derived types can allow equatability with parent types, I would suggest we merge this semi-hacky solution that allows our tests to pass. :)