### PR TITLE
Create converter to const date time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0
 
-- Add `DateTime` extension to convert to `ConstDateTime`. @jttuboi
+- Add `DateTime` extension to convert to `ConstDateTime`. ([#14](https://github.com/westy92/const-date-time/pull/14), thanks @jttuboi!)
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0
+
+- Add `DateTime` extension to convert to `ConstDateTime`. @jttuboi
+
 ## 1.1.0
 
 - Overrides `runtimeType`. ([#10](https://github.com/westy92/const-date-time/pull/10), thanks @ohitsdaniel!)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ constDateTime.add(Duration(minutes: 5));
 constDateTime.toIso8601String();
 ```
 
-You can convert a DateTime to ConstDateTime.
+You can convert a `DateTime` to a `ConstDateTime`.
 
 ```dart
 final dateTime = DateTime(2024);

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ constDateTime.add(Duration(minutes: 5));
 constDateTime.toIso8601String();
 ```
 
+You can convert a DateTime to ConstDateTime.
+
+```dart
+final dateTime = DateTime(2024);
+final ConstDateTime constDateTime = dateTime.toConstDateTime();
+```
+
 ## Sponsor
 
 Please consider [sponsoring my work](https://github.com/sponsors/westy92) to ensure this library receives the attention it deserves.

--- a/lib/src/to_const_date_time.dart
+++ b/lib/src/to_const_date_time.dart
@@ -1,0 +1,13 @@
+import 'package:const_date_time/const_date_time.dart';
+
+extension ConstDateTimeExtension on DateTime {
+  ConstDateTime toConstDateTime() {
+    if (isUtc) {
+      return ConstDateTime.utc(
+          year, month, day, hour, minute, second, millisecond, microsecond);
+    }
+
+    return ConstDateTime(
+        year, month, day, hour, minute, second, millisecond, microsecond);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: const_date_time
 description: A drop-in replacement for Dart's DateTime class with const constructors.
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/westy92/const-date-time
 issue_tracker: https://github.com/westy92/const-date-time/issues
 funding:

--- a/test/src/to_const_date_time_test.dart
+++ b/test/src/to_const_date_time_test.dart
@@ -7,15 +7,19 @@ void main() {
     test('must convert to normal ConstDateTime', () async {
       final dateTime = DateTime(2024, 12, 31, 23, 59, 51, 991, 999);
 
-      expect(dateTime.toConstDateTime(),
+      final constDateTime = dateTime.toConstDateTime();
+      expect(constDateTime,
           const ConstDateTime(2024, 12, 31, 23, 59, 51, 991, 999));
+      expect(constDateTime.isUtc, false);
     });
 
     test('must convert to utc ConstDateTime', () async {
       final dateTime = DateTime.utc(2024, 12, 31, 23, 59, 51, 991, 999);
 
-      expect(dateTime.toConstDateTime(),
+      final constDateTime = dateTime.toConstDateTime();
+      expect(constDateTime,
           const ConstDateTime.utc(2024, 12, 31, 23, 59, 51, 991, 999));
+      expect(constDateTime.isUtc, true);
     });
   });
 }

--- a/test/src/to_const_date_time_test.dart
+++ b/test/src/to_const_date_time_test.dart
@@ -1,0 +1,21 @@
+import 'package:const_date_time/src/const_date_time.dart';
+import 'package:const_date_time/src/to_const_date_time.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ConstDateTimeExtension', () {
+    test('must convert to normal ConstDateTime', () async {
+      final dateTime = DateTime(2024, 12, 31, 23, 59, 51, 991, 999);
+
+      expect(dateTime.toConstDateTime(),
+          const ConstDateTime(2024, 12, 31, 23, 59, 51, 991, 999));
+    });
+
+    test('must convert to utc ConstDateTime', () async {
+      final dateTime = DateTime.utc(2024, 12, 31, 23, 59, 51, 991, 999);
+
+      expect(dateTime.toConstDateTime(),
+          const ConstDateTime.utc(2024, 12, 31, 23, 59, 51, 991, 999));
+    });
+  });
+}


### PR DESCRIPTION
Hi, I would like to improve your package.

I added the extension `toConstDateTime()` to a `DateTime` type to make it easier to convert into `ConstDateTime`.

I checked the dart version extension and is 2.7.0, so don't need upgrade or something.